### PR TITLE
Refactor : Emotion 컴포넌트명 변경(ImageSlider => ImageList)

### DIFF
--- a/src/domain/RoomDetail/ImageList.tsx
+++ b/src/domain/RoomDetail/ImageList.tsx
@@ -10,16 +10,16 @@ interface ImageSliderProps {
   files: file[];
 }
 
-const ImageSlider: FC<ImageSliderProps> = ({ files }) => {
+const ImageList: FC<ImageSliderProps> = ({ files }) => {
   return (
     <>
       {files?.length === 0 && <p>등록된 이미지가 없습니다 🥲</p>}
-      <Slider>
+      <List>
         {files?.map((file) => {
           const fileName = file?.fileNm;
 
           return (
-            <ImageBox key={fileName}>
+            <ListItem key={fileName}>
               <Image
                 loader={myLoader}
                 src={fileName}
@@ -27,15 +27,15 @@ const ImageSlider: FC<ImageSliderProps> = ({ files }) => {
                 height="300"
                 alt={fileName}
               />
-            </ImageBox>
+            </ListItem>
           );
         })}
-      </Slider>
+      </List>
     </>
   );
 };
 
-export const Slider = styled.ul`
+export const List = styled.ul`
   display: flex;
   justify-content: space-between;
   gap: 20px;
@@ -43,8 +43,8 @@ export const Slider = styled.ul`
   background: #fff;
 `;
 
-export const ImageBox = styled.li`
+export const ListItem = styled.li`
   width: calc(50% - 10px);
 `;
 
-export default ImageSlider;
+export default ImageList;

--- a/src/domain/RoomDetail/TopContents.tsx
+++ b/src/domain/RoomDetail/TopContents.tsx
@@ -1,13 +1,14 @@
 import styled from "@emotion/styled";
+
 import { FaStar } from "react-icons/fa";
 import { GrFormView } from "react-icons/gr";
 
 import { colorPalette } from "../../config/color-config";
 
-import ImageSlider from "./ImageSlider";
+import ImageList from "./ImageList";
 
-const TopContents = ({ titleData, files }) => {
-  const { name, rating, views } = titleData;
+const TopContents = ({ detailData }) => {
+  const { name, rating, views, files } = detailData || {};
 
   return (
     <section>
@@ -24,7 +25,7 @@ const TopContents = ({ titleData, files }) => {
           </span>
         </p>
       </Head>
-      <ImageSlider files={files} />
+      <ImageList files={files} />
     </section>
   );
 };


### PR DESCRIPTION
현재 이미지가 슬라이드 형태가 아닌 리스트 형태이기 때문에 ImageSlider 라는 이름보다
ImageList가 컴포넌트의 의도를 더 드러낼 수 있다고 판단하여 컴포넌트명을 변경합니다

[상세페이지 이미지 UI]
![image](https://user-images.githubusercontent.com/53102889/132943532-417a59ef-bf50-47cb-830c-7a1681602265.png)