### PR TITLE
Feat : 어드민 로그인 페이지 생성 ( + LoginForm 리팩터링 ) 

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,10 +4,16 @@ import { CookiesProvider } from "react-cookie";
 import { Global } from "@emotion/react";
 import axios from "axios";
 
-import globalStyle from "../src/styles/GlobalCss";
 import { BACKEND_SERVER_URL } from "../src/constants/server";
+import globalStyle from "../src/styles/GlobalCss";
 import AppLayout from "../src/components/AppLayout";
-import { isMainPage, isUnVisibleSearchForm } from "../src/utils/path";
+import AdminLayout from "../src/components/AdminLayout";
+import {
+  isAdminPage,
+  isMainPage,
+  isUnVisibleSearchForm,
+  isVisibleNav,
+} from "../src/utils/path";
 
 axios.defaults.baseURL = BACKEND_SERVER_URL;
 
@@ -17,12 +23,18 @@ function MyApp({ Component, pageProps }: AppProps) {
   return (
     <CookiesProvider>
       <Global styles={globalStyle} />
-      <AppLayout
-        isMainPage={isMainPage(pathname)}
-        isUnVisibleSearchForm={isUnVisibleSearchForm(pathname)}
-      >
-        <Component {...pageProps} />
-      </AppLayout>
+      {isAdminPage({ pathname }) ? (
+        <AdminLayout isVisibleNav={isVisibleNav(pathname)}>
+          <Component {...pageProps} />
+        </AdminLayout>
+      ) : (
+        <AppLayout
+          isMainPage={isMainPage(pathname)}
+          isUnVisibleSearchForm={isUnVisibleSearchForm(pathname)}
+        >
+          <Component {...pageProps} />
+        </AppLayout>
+      )}
     </CookiesProvider>
   );
 }

--- a/pages/admin/home.tsx
+++ b/pages/admin/home.tsx
@@ -1,0 +1,17 @@
+import styled from "@emotion/styled";
+
+const Home = () => {
+  return (
+    <article>
+      <Title>관리자 홈</Title>
+    </article>
+  );
+};
+
+const Title = styled.h2`
+  margin-bottom: 30px;
+  font-size: 30px;
+  text-align: center;
+`;
+
+export default Home;

--- a/pages/admin/login.tsx
+++ b/pages/admin/login.tsx
@@ -1,0 +1,85 @@
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import styled from "@emotion/styled";
+
+import { postAdminLogin } from "../../src/api/user/postAdminLogin";
+import LoginForm from "../../src/domain/Login/LoginForm";
+
+import {
+  useLogin,
+  useLoginCookie,
+  useLoginUserInfo,
+} from "../../src/domain/Login/hooks";
+
+import { TCookieKey, TStotageKey } from "../../src/domain/Login/type";
+import { setUserInfo } from "../../src/domain/Login/utils";
+
+const Admin = () => {
+  const router = useRouter();
+
+  const cookieKey: TCookieKey = "AdminAuthorization";
+  const storageKey: TStotageKey = "adminUserInfo";
+
+  const { handleSetCookie } = useLoginCookie({ cookieKey });
+  const { user, handleSetUser } = useLoginUserInfo({ storageKey });
+  const { loginFields, loginError, handleChange, handleSetLoginError } =
+    useLogin();
+
+  const { id, password } = loginFields;
+
+  useEffect(() => {
+    if (user) {
+      router.push("/admin/home");
+    }
+  }, [user]);
+
+  const handleSubmit = async (e: React.FormEvent): Promise<void> => {
+    e.preventDefault();
+
+    try {
+      const result = await postAdminLogin({ id, password });
+
+      setUserInfo({
+        userInfo: result,
+        cookieKey: "AdminAuthorization",
+        storageKey: "adminUserInfo",
+        setUser: handleSetUser,
+        setCookie: handleSetCookie,
+      });
+    } catch (e) {
+      handleSetLoginError({ message: e?.message });
+    }
+  };
+
+  if (user) {
+    return null;
+  }
+
+  return (
+    <Container>
+      <Title>관리자 로그인</Title>
+      <LoginForm
+        loginFields={loginFields}
+        onSubmit={handleSubmit}
+        onChange={handleChange}
+        loginError={loginError}
+      />
+    </Container>
+  );
+};
+
+const Container = styled.main`
+  position: fixed;
+  left: 50%;
+  top: 50%;
+  width: 500px;
+  transform: translate(-50%, -50%);
+`;
+
+const Title = styled.h2`
+  margin-bottom: 30px;
+  font-size: 30px;
+  text-align: center;
+`;
+
+export default Admin;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,8 @@
+import Link from "next/Link";
 import Head from "next/head";
 
 import styled from "@emotion/styled";
+import { useLoginUserInfo } from "../src/domain/Login/hooks";
 
 const Home = () => {
   return (
@@ -18,9 +20,6 @@ const Home = () => {
             <span>여행 등 다양한 목적에 맞는 숙소를 찾아보세요</span>
           </p>
         </VisualBanner>
-        <AdminButton onClick={() => alert("준비중입니다.")}>
-          <button type="button">관리자 페이지로 이동</button>
-        </AdminButton>
       </main>
     </>
   );
@@ -51,7 +50,7 @@ const VisualBanner = styled.section({
   },
 });
 
-const AdminButton = styled.section({
+const AdminButton = styled(Link)({
   margin: "2rem",
   button: {
     width: "100%",

--- a/src/api/user/postAdminLogin.ts
+++ b/src/api/user/postAdminLogin.ts
@@ -1,0 +1,20 @@
+import axios from "axios";
+
+export const postAdminLogin = async ({
+  id,
+  password,
+}: {
+  id: string;
+  password: string;
+}) => {
+  const result = await axios.post("/admin/signIn", {
+    id,
+    password,
+  });
+
+  if (!result.data.completed) {
+    throw new Error("아이디 또는 비밀번호를 확인해주세요");
+  }
+
+  return result.data.resultValue;
+};

--- a/src/components/AdminLayout.tsx
+++ b/src/components/AdminLayout.tsx
@@ -1,0 +1,26 @@
+import React, { FC } from "react";
+
+export type AdminLayoutProps = {
+  children: React.ReactNode;
+  isVisibleNav: boolean;
+};
+
+const AdminLayout: FC<AdminLayoutProps> = ({ children, isVisibleNav }) => {
+  return (
+    <>
+      {isVisibleNav && (
+        <nav>
+          <ul>
+            <li>1</li>
+            <li>1</li>
+            <li>1</li>
+            <li>1</li>
+          </ul>
+        </nav>
+      )}
+      {children}
+    </>
+  );
+};
+
+export default AdminLayout;

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -1,19 +1,21 @@
-import React, { useState, useEffect, FC } from "react";
-import { useCookies } from "react-cookie";
-import axios from "axios";
+import React, { useState, FC } from "react";
 
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 
-import Modal from "./Modal";
 import RoomSearchForm from "../domain/RoomSearch/SearchForm/RoomSearchForm";
 import LoginForm from "../domain/Login/LoginForm";
+import Modal from "./Modal";
+import HamburgerMenu from "./HamburgerMenu";
 
 import {
-  getLocalStorageItem,
-  removeLocalStorageItem,
-} from "../utils/localStorage";
-import HamburgerMenu from "./HamburgerMenu";
+  useLogin,
+  useLoginCookie,
+  useLoginUserInfo,
+} from "../domain/Login/hooks";
+import { setUserInfo, removeUserInfo } from "../domain/Login/utils";
+import { TCookieKey, TStotageKey } from "../domain/Login/type";
+import { postLogin } from "../api/user/postLogin";
 
 export type AppLayoutProps = {
   children: React.ReactNode;
@@ -26,54 +28,58 @@ const AppLayout: FC<AppLayoutProps> = ({
   isMainPage,
   isUnVisibleSearchForm,
 }) => {
-  const [cookies, setCookie, removeCookie] = useCookies(["Authorization"]);
-
-  const [user, setUser] = useState(null);
-
   const [toggleMenuOpen, setToggleMenuOpen] = useState(false);
   const [loginFormOpen, setLoginFormOepn] = useState(false);
 
-  const handleSetUser = (userInfo) => {
-    setUser(userInfo);
+  const cookieKey: TCookieKey = "Authorization";
+  const storageKey: TStotageKey = "userInfo";
+
+  const { removeCookie, handleSetCookie } = useLoginCookie({ cookieKey });
+  const { user, handleSetUser } = useLoginUserInfo({ storageKey });
+  const { loginFields, loginError, handleChange, handleSetLoginError } =
+    useLogin();
+
+  const { id, password } = loginFields;
+
+  const handleToggleMenuVisible = (status: boolean) => {
+    setToggleMenuOpen(status);
   };
 
-  const handleSetCookie = ({ key, value }) => {
-    setCookie(key, value);
+  const handleLoginModalVisible = (status: boolean) => {
+    setLoginFormOepn(status);
+  };
+
+  const handleSubmit = async (e: React.FormEvent): Promise<void> => {
+    e.preventDefault();
+
+    try {
+      const result = await postLogin({ id, password });
+
+      setUserInfo({
+        userInfo: result,
+        storageKey: "userInfo",
+        cookieKey: "Authorization",
+        setUser: handleSetUser,
+        setCookie: handleSetCookie,
+      });
+
+      handleToggleMenuVisible(false);
+      handleLoginModalVisible(false);
+
+      handleSetLoginError(null);
+    } catch (e) {
+      handleSetLoginError({ message: e.message });
+    }
   };
 
   const handleLogoutClick = () => {
-    removeCookie("Authorization");
-    removeLocalStorageItem({ key: "userInfo" });
-    handleSetUser(null);
+    removeUserInfo({
+      cookieKey,
+      storageKey,
+      removeCookie,
+      setUser: handleSetUser,
+    });
   };
-
-  const handleLoginModalToggle = () => {
-    setLoginFormOepn((prev) => !prev);
-  };
-
-  const handleMenuButtonClickToggle = () => {
-    setToggleMenuOpen((prev) => !prev);
-  };
-
-  const handleToggleMenuClose = () => {
-    setToggleMenuOpen(false);
-  };
-
-  const handleLoginFormClose = () => {
-    setLoginFormOepn(false);
-  };
-
-  useEffect(() => {
-    handleSetUser(getLocalStorageItem({ key: "userInfo" }));
-  }, []);
-
-  useEffect(() => {
-    if (cookies) {
-      axios.defaults.headers.common[
-        "Authorization"
-      ] = `Bearer ${cookies.Authorization}`;
-    }
-  }, [cookies]);
 
   return (
     <>
@@ -85,18 +91,23 @@ const AppLayout: FC<AppLayoutProps> = ({
         <HamburgerMenu
           toggleMenuOpen={toggleMenuOpen}
           user={user}
-          onMenuButtonClickToggle={handleMenuButtonClickToggle}
-          onLoginModalToggle={handleLoginModalToggle}
+          onMenuButtonClickToggle={() =>
+            handleToggleMenuVisible(!toggleMenuOpen)
+          }
+          onLoginModalToggle={() => handleLoginModalVisible(!loginFormOpen)}
           onLogoutClick={handleLogoutClick}
         />
       </Header>
       {loginFormOpen && (
-        <Modal title="로그인" onOutsideClick={handleLoginModalToggle}>
+        <Modal
+          title="로그인"
+          onOutsideClick={() => handleLoginModalVisible(false)}
+        >
           <LoginForm
-            setCookie={handleSetCookie}
-            setUser={handleSetUser}
-            onLoginFormClose={handleLoginFormClose}
-            onToggleMenuClose={handleToggleMenuClose}
+            loginFields={loginFields}
+            loginError={loginError}
+            onSubmit={handleSubmit}
+            onChange={handleChange}
           />
         </Modal>
       )}

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -33,9 +33,14 @@ const AppLayout: FC<AppLayoutProps> = ({
 
   const cookieKey: TCookieKey = "Authorization";
   const storageKey: TStotageKey = "userInfo";
+  const adminstorageKey: TStotageKey = "adminUserInfo";
 
   const { removeCookie, handleSetCookie } = useLoginCookie({ cookieKey });
   const { user, handleSetUser } = useLoginUserInfo({ storageKey });
+  const { user: adminUser } = useLoginUserInfo({
+    storageKey: adminstorageKey,
+  });
+
   const { loginFields, loginError, handleChange, handleSetLoginError } =
     useLogin();
 
@@ -91,6 +96,7 @@ const AppLayout: FC<AppLayoutProps> = ({
         <HamburgerMenu
           toggleMenuOpen={toggleMenuOpen}
           user={user}
+          adminUser={adminUser}
           onMenuButtonClickToggle={() =>
             handleToggleMenuVisible(!toggleMenuOpen)
           }

--- a/src/components/HamburgerMenu.tsx
+++ b/src/components/HamburgerMenu.tsx
@@ -1,10 +1,12 @@
 import styled from "@emotion/styled";
+import Link from "next/Link";
 
 import { IoMdMenu } from "react-icons/io";
 
 const HamburgerMenu = ({
   toggleMenuOpen,
   user,
+  adminUser,
   onMenuButtonClickToggle,
   onLoginModalToggle,
   onLogoutClick,
@@ -39,6 +41,11 @@ const HamburgerMenu = ({
               </button>
             )}
           </li>
+          <li>
+            <Link href={adminUser ? "/admin/home" : "/admin/login"}>
+              <button type="button">관리자 페이지</button>
+            </Link>
+          </li>
         </ToggleMenus>
       )}
     </>
@@ -56,6 +63,7 @@ const ToggleMenuButton = styled.div`
     margin: auto 0;
     padding: 0.4em 0.5em 0.4em 1em;
     cursor: pointer;
+
     .menu svg {
       font-size: 1.6rem;
     }
@@ -80,7 +88,11 @@ const ToggleMenus = styled.ul`
   border-radius: 10px;
   background: #fff;
   box-shadow: 1px 1px 10px rgba(0, 0, 0, 0.3);
-  li button {
+  li + li {
+    border-top: 1px solid #dcdcdc;
+  }
+  li button,
+  li a {
     padding: 20px;
     width: 100%;
     text-align: left;

--- a/src/domain/Login/LoginForm.tsx
+++ b/src/domain/Login/LoginForm.tsx
@@ -4,32 +4,25 @@ import styled from "@emotion/styled";
 
 import { colorPalette } from "../../config/color-config";
 
-import useLogin from "./hooks/useLogin";
+import { IloginFields } from "./type";
 
 interface ILoginForm {
-  setCookie: ({ key, value }: { key: string; value: string }) => void;
-  setUser: (value) => void;
-  onLoginFormClose: () => void;
-  onToggleMenuClose: () => void;
+  loginFields: IloginFields;
+  loginError: string;
+  onSubmit: (e: React.FormEvent) => Promise<void>;
+  onChange: (e: React.FormEvent) => void;
 }
 
 const LoginForm: FC<ILoginForm> = ({
-  setCookie,
-  setUser,
-  onLoginFormClose,
-  onToggleMenuClose,
+  loginFields,
+  loginError,
+  onSubmit,
+  onChange,
 }) => {
-  const { loginFields, loginError, handleSubmit, handleChange } = useLogin({
-    setCookie,
-    setUser,
-    onLoginFormClose,
-    onToggleMenuClose,
-  });
-
   const { id, password } = loginFields;
 
   return (
-    <Form onSubmit={handleSubmit}>
+    <Form onSubmit={onSubmit}>
       <p>
         <input
           id="id"
@@ -37,7 +30,7 @@ const LoginForm: FC<ILoginForm> = ({
           type="text"
           value={id}
           placeholder="id"
-          onChange={handleChange}
+          onChange={onChange}
         />
       </p>
       <p>
@@ -47,7 +40,7 @@ const LoginForm: FC<ILoginForm> = ({
           type="password"
           value={password}
           placeholder="password"
-          onChange={handleChange}
+          onChange={onChange}
         />
       </p>
       {loginError && <Error>{loginError}</Error>}

--- a/src/domain/Login/hooks/index.ts
+++ b/src/domain/Login/hooks/index.ts
@@ -1,0 +1,3 @@
+export { default as useLoginCookie } from "./useLoginCookie";
+export { default as useLoginUserInfo } from "./useLoginUserInfo";
+export { default as useLogin } from "./useLogin";

--- a/src/domain/Login/hooks/useLogin.ts
+++ b/src/domain/Login/hooks/useLogin.ts
@@ -1,24 +1,24 @@
 import { ChangeEvent, useState } from "react";
-import { postLogin } from "../../../api/user/postLogin";
-import {
-  getLocalStorageItem,
-  setLocalStorageItem,
-} from "../../../utils/localStorage";
 
-const useLogin = ({
-  setCookie,
-  setUser,
-  onLoginFormClose,
-  onToggleMenuClose,
-}) => {
-  const [loginFields, setLoginFields] = useState({
+import { IloginFields } from "../type";
+
+interface IUserLoginReturnValue {
+  loginFields: IloginFields;
+  loginError: string;
+  handleChange: (e: React.FormEvent) => void;
+  handleSetLoginError: ({ message }: { message: string }) => void;
+}
+
+const useLogin = (): IUserLoginReturnValue => {
+  const [loginFields, setLoginFields] = useState<IloginFields>({
     id: "",
     password: "",
   });
+  const [loginError, setLoginError] = useState<string | null>(null);
 
-  const { id, password } = loginFields;
-
-  const [loginError, setLoginError] = useState(null);
+  const handleSetLoginError = ({ message }: { message: string }) => {
+    setLoginError(message);
+  };
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
@@ -29,34 +29,7 @@ const useLogin = ({
     }));
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-
-    try {
-      const result = await postLogin({ id, password });
-      const accessToken = result.token;
-
-      const { nickname, userId, userSeq } = result;
-
-      setCookie({ key: "Authorization", value: accessToken });
-
-      setLocalStorageItem({
-        key: "userInfo",
-        value: JSON.stringify({ nickname, userId, userSeq }),
-      });
-
-      setLoginError(null);
-
-      setUser(getLocalStorageItem({ key: "userInfo" }));
-
-      onLoginFormClose();
-      onToggleMenuClose();
-    } catch (e) {
-      setLoginError(e.message);
-    }
-  };
-
-  return { loginFields, loginError, handleChange, handleSubmit };
+  return { loginFields, loginError, handleChange, handleSetLoginError };
 };
 
 export default useLogin;

--- a/src/domain/Login/hooks/useLoginCookie.ts
+++ b/src/domain/Login/hooks/useLoginCookie.ts
@@ -1,0 +1,40 @@
+import axios from "axios";
+import { useEffect } from "react";
+import { useCookies } from "react-cookie";
+
+import { TCookieKey } from "../type";
+
+export interface IuseLoginCookieReturnValue {
+  cookies: {
+    Authorization?: string;
+    AdminAuthorization?: string;
+  };
+  removeCookie: (cookieKey: TCookieKey) => void;
+  handleSetCookie: ({ key, value }: { key: string; value: string }) => void;
+}
+
+const useLoginCookie = ({
+  cookieKey,
+}: {
+  cookieKey: TCookieKey;
+}): IuseLoginCookieReturnValue => {
+  const [cookies, setCookie, removeCookie] = useCookies([cookieKey]);
+
+  useEffect(() => {
+    if (cookies) {
+      axios.defaults.headers.common[
+        "Authorization"
+      ] = `Bearer ${cookies[cookieKey]}`;
+    }
+  }, [cookies, cookieKey]);
+
+  const handleSetCookie = ({ key, value }) => setCookie(key, value);
+
+  return {
+    cookies,
+    removeCookie,
+    handleSetCookie,
+  };
+};
+
+export default useLoginCookie;

--- a/src/domain/Login/hooks/useLoginUserInfo.ts
+++ b/src/domain/Login/hooks/useLoginUserInfo.ts
@@ -1,0 +1,32 @@
+import axios from "axios";
+import { useEffect, useState } from "react";
+
+import { getLocalStorageItem } from "../../../utils/localStorage";
+
+import { IUserInfo, TStotageKey } from "../type";
+
+interface IUseLoginUserInfoReturnValue {
+  user: IUserInfo;
+  handleSetUser: (userInfo: IUserInfo) => void;
+}
+
+const useLoginUserInfo = ({
+  storageKey,
+}: {
+  storageKey: TStotageKey;
+}): IUseLoginUserInfoReturnValue => {
+  const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    handleSetUser(getLocalStorageItem({ key: storageKey }));
+  }, [storageKey]);
+
+  const handleSetUser = (userInfo) => setUser(userInfo);
+
+  return {
+    user,
+    handleSetUser,
+  };
+};
+
+export default useLoginUserInfo;

--- a/src/domain/Login/type/index.ts
+++ b/src/domain/Login/type/index.ts
@@ -1,0 +1,13 @@
+export type TStotageKey = "userInfo" | "adminUserInfo";
+export type TCookieKey = "Authorization" | "AdminAuthorization";
+
+export interface IloginFields {
+  id: string;
+  password: string;
+}
+
+export interface IUserInfo {
+  nickname: string;
+  userId: string;
+  userSeq: number;
+}

--- a/src/domain/Login/utils/index.ts
+++ b/src/domain/Login/utils/index.ts
@@ -1,0 +1,2 @@
+export { default as removeUserInfo } from "./removeUserInfo";
+export { default as setUserInfo } from "./setUserInfo";

--- a/src/domain/Login/utils/removeUserInfo.ts
+++ b/src/domain/Login/utils/removeUserInfo.ts
@@ -1,0 +1,24 @@
+import { removeLocalStorageItem } from "../../../utils/localStorage";
+import { TCookieKey, TStotageKey } from "../type";
+
+interface IremoveUserInfo {
+  cookieKey: TCookieKey;
+  storageKey: TStotageKey;
+  removeCookie: (cookieKey: TCookieKey) => void;
+  setUser: (userInfo: null) => void;
+}
+
+const removeUserInfo = ({
+  cookieKey,
+  storageKey,
+  removeCookie,
+  setUser,
+}: IremoveUserInfo) => {
+  removeCookie(cookieKey);
+
+  removeLocalStorageItem({ key: storageKey });
+
+  setUser(null);
+};
+
+export default removeUserInfo;

--- a/src/domain/Login/utils/setUserInfo.ts
+++ b/src/domain/Login/utils/setUserInfo.ts
@@ -1,0 +1,35 @@
+import { IPostLoginResultValue } from "../../../api/user/postLogin";
+import {
+  getLocalStorageItem,
+  setLocalStorageItem,
+} from "../../../utils/localStorage";
+import { IUserInfo, TCookieKey, TStotageKey } from "../type";
+
+const setUserInfo = async ({
+  userInfo,
+  cookieKey,
+  storageKey,
+  setCookie,
+  setUser,
+}: {
+  userInfo: IPostLoginResultValue;
+  cookieKey: TCookieKey;
+  storageKey: TStotageKey;
+  setCookie: ({ key, value }: { key: TCookieKey; value: string }) => void;
+  setUser: (userInfo: IUserInfo) => void;
+}) => {
+  const accessToken = userInfo.token;
+
+  const { nickname, userId, userSeq } = userInfo;
+
+  setCookie({ key: cookieKey, value: accessToken });
+
+  setLocalStorageItem({
+    key: storageKey,
+    value: JSON.stringify({ nickname, userId, userSeq }),
+  });
+
+  setUser(getLocalStorageItem({ key: storageKey }));
+};
+
+export default setUserInfo;

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -71,9 +71,20 @@ export const createRoomReservationConfirmPath = ({
 };
 
 export const isMainPage = (path: string) => path === "/";
+export const isAdminPage = ({ pathname }) => {
+  const result = pathname.includes("admin");
+
+  return result;
+};
 
 export const isUnVisibleSearchForm = (path: string) => {
   const unVisiblePath = ["/reservationConfirm", "/reservationResult/[status]"];
 
   return unVisiblePath.includes(path);
+};
+
+export const isVisibleNav = (path: string): boolean => {
+  const unVisiblePath = ["/admin/login"];
+
+  return !unVisiblePath.includes(path);
 };


### PR DESCRIPTION
- LoginForm 컴포넌트를 사용하는 측에서 onSubmit 함수를 정의하고 LoginForm 컴포넌트의 props로 받도록 수정하였습니다
- 로그인시 사용되는 쿠키, 유저 정보 사용 로직을 재사용이 가능하도록 custom hooks로 분리하였습니다
  (useLoginCookie, useLoginUserInfo)
- 로그아웃시 반복적으로 사용되는 로직을 재사용 가능한 함수로 분리하였습니다(removeUserInfo)